### PR TITLE
Additional handling for empty config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,19 +40,19 @@ services:
       retries: 5
 
 ### Only for local deployment of VSE Search stack
-#  vse:
-#    image: videntifier/vse-stack:6.5.1
-#    ports:
-#      - "5555:9001"
-#      - "7771:7771"
-#    container_name: vse
-#    volumes:
-#      - ./db/database:/mnt/database
-#      - ./db/config/vse-config.yaml:/app/VSE/vse-config.yaml
-#      - ./db/config/supervisord.conf:/app/supervisord.conf
-#    restart: always
-#    networks:
-#      - mediaguard-net
+  # vse:
+  #   image: videntifier/vse-stack:6.5.1
+  #   ports:
+  #     - "5555:9001"
+  #     - "7771:7771"
+  #   container_name: vse
+  #   volumes:
+  #     - ./db/database:/mnt/database
+  #     - ./db/config/vse-config.yaml:/app/VSE/vse-config.yaml
+  #     - ./db/config/supervisord.conf:/app/supervisord.conf
+  #   restart: always
+  #   networks:
+  #     - mediaguard-net
 
 volumes:
   mediaguard-data:

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -82,7 +82,10 @@ func (h *Handlers) parseCreateHashesRequest(r *http.Request) (*multipart.FileHea
 
 	var config models.HashConfig
 	configStr := r.FormValue("config")
-	if configStr != "" {
+
+	if configStr == "" {
+		return nil, nil, nil, fmt.Errorf("config parameter is required and cannot be empty")
+	} else {
 		if err := json.Unmarshal([]byte(configStr), &config); err != nil {
 			return nil, nil, nil, fmt.Errorf("invalid config JSON: %w", err)
 		}
@@ -190,6 +193,12 @@ func (h *Handlers) getWatermarkHistory(ctx context.Context, fileUUID uuid.UUID) 
 
 // areAllHashesPresent checks if all requested hashes are already in the database.
 func areAllHashesPresent(requestedAlgos []models.HashAlgorithmConfig, storedHashes map[string]string) bool {
+
+	if len(requestedAlgos) == 0 {
+		return false
+	}
+
+	log.Printf("[DEBUG] Checking for presence of %d algorithms", len(requestedAlgos))
 	for _, algo := range requestedAlgos {
 		if _, ok := storedHashes[algo.Algorithm]; !ok {
 			return false


### PR DESCRIPTION
Fixes issue where the config is submitted as empty.
This caused the algorithm listing to be empty so an entry was created for the file but no hashes registered. 
This then caused an empty list of hashes to be returned.

This condition is now checked for.